### PR TITLE
removed zoom z changes.

### DIFF
--- a/public/js/library/TrackBallControls.js
+++ b/public/js/library/TrackBallControls.js
@@ -506,20 +506,20 @@ THREE.TrackballControls = function ( object, domElement ) {
 
 		switch ( event.deltaMode ) {
 
-			case 2:
-				// Zoom in pages
-				_zoomStart.y -= event.deltaY * 0.025;
-				break;
+			// case 2:
+			// 	// Zoom in pages
+			// 	_zoomStart.y -= event.deltaY * 0.025;
+			// 	break;
 
-			case 1:
-				// Zoom in lines
-				_zoomStart.y -= event.deltaY * 0.01;
-				break;
+			// case 1:
+			// 	// Zoom in lines
+			// 	_zoomStart.y -= event.deltaY * 0.01;
+			// 	break;
 
-			default:
-				// undefined, 0, assume pixels
-				_zoomStart.y -= event.deltaY * 0.00025;
-				break;
+			// default:
+			// 	// undefined, 0, assume pixels
+			// 	_zoomStart.y -= event.deltaY * 0.00025;
+			// 	break;
 
 		}
 


### PR DESCRIPTION
Made it so zoom doesn't change the z value and instead JUST modifies the magnification value.  

If we want to go back to perspective camera this will be an issue.