### PR TITLE
Incorporate database import functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,15 +43,15 @@
 						<div id='unitsflex'>
 							<span class='unitsheader'>
 								a
-								<input id='lengthX' name='LatticeA' type='number' value='5.431'>
+								<input id='lengthX' name='LatticeA' type='number' value='.5431'>
 							</span>
 							<span class='unitsheader'>
 								b
-								<input id='lengthY' name='LatticeB' type='number' value='5.431'>
+								<input id='lengthY' name='LatticeB' type='number' value='.5431'>
 							</span>
 							<span class='unitsheader'>
 								c
-								<input id='lengthZ' name='LatticeC' type='number' value='5.431'>
+								<input id='lengthZ' name='LatticeC' type='number' value='.5431'>
 							</span>
 							<span class='unitsheader'>
 								Alpha

--- a/index.html
+++ b/index.html
@@ -21,18 +21,18 @@
 						<label id='latticetitle' for='latticeselector'>Bravias lattice</label>
 						<select name='CrystalStructure' id='latticeselector'>
 							<option value='Primitive Cubic'>Primitive Cubic</option>
-							<option value='bcc'>bcc</option>
-							<option value='fcc'>fcc</option>
-							<option value='Tetragonal'>Tetragonal</option>
-							<option value='Body centered Tetragonal'>Body centered Tetragonal</option>
-							<option value='Orthohombic'>Orthohombic</option>
+							<option value='Body Centered Cubic'>Body Centered Cubic</option>
+							<option value='Face Centered Cubic'>Face Centered Cubic</option>
+							<option value='Primitive Tetragonal'>Primitive Tetragonal</option>
+							<option value='Body Centered Tetragonal'>Body Centered Tetragonal</option>
+							<option value='Primitive Orthohombic'>Primitive Orthohombic</option>
 							<option value='Body Centered Orthohombic'>Body Centered Orthohombic</option>
 							<option value='Face Centered Orthohombic'>Face Centered Orthohombic</option>
-							<option value='End Centered Orthohombic'>End Centered Orthohombic</option>
+							<option value='Base Centered Orthohombic'>Base Centered Orthohombic</option>
 							<option value='Hexagonal'>Hexagonal</option>
 							<option value='Rhombohedral'>Rhombohedral</option>
-							<option value='Monoclinic'>Monoclinic</option>
-							<option value='End Centered Monoclinic'>End Centered Monoclinic</option>
+							<option value='Primitive Monoclinic'>Primitive Monoclinic</option>
+							<option value='Base Centered Monoclinic'>Base Centered Monoclinic</option>
 							<option value='Triclinic'>Triclinic</option>
 						</select>
 						<input type='number' id='latticeweight' value='4' max='7' min='1'>

--- a/index.html
+++ b/index.html
@@ -43,15 +43,15 @@
 						<div id='unitsflex'>
 							<span class='unitsheader'>
 								a
-								<input id='lengthX' name='LatticeA' type='number' value='.5431' step='any'>
+								<input id='lengthX' name='LatticeA' type='number' value='5.431' step='any'>
 							</span>
 							<span class='unitsheader'>
 								b
-								<input id='lengthY' name='LatticeB' type='number' value='.5431' step='any'>
+								<input id='lengthY' name='LatticeB' type='number' value='5.431' step='any'>
 							</span>
 							<span class='unitsheader'>
 								c
-								<input id='lengthZ' name='LatticeC' type='number' value='.5431' step='any'>
+								<input id='lengthZ' name='LatticeC' type='number' value='5.431' step='any'>
 							</span>
 							<span class='unitsheader'>
 								Alpha

--- a/index.html
+++ b/index.html
@@ -42,15 +42,15 @@
 						<p>Units</p>
 						<div id='unitsflex'>
 							<span class='unitsheader'>
-								a
+								a (Å)
 								<input id='lengthX' name='LatticeA' type='number' value='5.431' step='any'>
 							</span>
 							<span class='unitsheader'>
-								b
+								b (Å)
 								<input id='lengthY' name='LatticeB' type='number' value='5.431' step='any'>
 							</span>
 							<span class='unitsheader'>
-								c
+								c (Å)
 								<input id='lengthZ' name='LatticeC' type='number' value='5.431' step='any'>
 							</span>
 							<span class='unitsheader'>
@@ -71,7 +71,7 @@
 						<p>Coordinates of Atoms</p>
 						<div id='atomsflex'>
 							<span>
-								<p>element</p>
+								<p>Element</p>
 								<div id='elementinput'>H</div>
 							</span>
 							<span>

--- a/index.html
+++ b/index.html
@@ -43,15 +43,15 @@
 						<div id='unitsflex'>
 							<span class='unitsheader'>
 								a
-								<input id='lengthX' name='LatticeA' type='number' value='.5431'>
+								<input id='lengthX' name='LatticeA' type='number' value='.5431' step='any'>
 							</span>
 							<span class='unitsheader'>
 								b
-								<input id='lengthY' name='LatticeB' type='number' value='.5431'>
+								<input id='lengthY' name='LatticeB' type='number' value='.5431' step='any'>
 							</span>
 							<span class='unitsheader'>
 								c
-								<input id='lengthZ' name='LatticeC' type='number' value='.5431'>
+								<input id='lengthZ' name='LatticeC' type='number' value='.5431' step='any'>
 							</span>
 							<span class='unitsheader'>
 								Alpha

--- a/index.html
+++ b/index.html
@@ -149,8 +149,7 @@
 						<button id='exportdatabasebutton' type='submit'>Database</button>
 						<button id='exportlocallybutton' type='button'>Locally</button>
 						<span id='importheader'>Import</span>
-						<select id='importdatabasemenu'>
-							<option>Silicon</option>
+						<select id='importdatabasemenu' onchange='importDatabaseSpecimen()'>
 						</select>
 						<input type='file' id='importlocallybutton'/>
 						<span id='backgroundcolor'>Background Color</span>

--- a/public/js/Specimen.js
+++ b/public/js/Specimen.js
@@ -1,14 +1,15 @@
 class Specimen{
   constructor(shape, countX, countY, countZ, lengthA, lengthB, lengthC, angleA, angleB, angleC, scene, lineWeight){
+    this.mag = 10;
     this.latticeColor = 0xff37d8;
     switch(shape){
     case 'square':
       this.shape = new THREE.Geometry();
       this.material = new THREE.LineBasicMaterial({color: this.latticeColor, linewidth: lineWeight});
       
-      this.lengthX = Number(lengthA);
-      this.lengthY = Number(lengthB);
-      this.lengthZ = Number(lengthC);
+      this.lengthX = Number(lengthA) * this.mag;
+      this.lengthY = Number(lengthB) * this.mag;
+      this.lengthZ = Number(lengthC) * this.mag;
       break;
     }
     this.countX = countX;
@@ -31,7 +32,6 @@ class Specimen{
     this.crystalCount = 0;
 
     this.zero = 0;
-    this.mag = 1.0;
   }
 
   createCrystals(){

--- a/public/js/Specimen.js
+++ b/public/js/Specimen.js
@@ -1,6 +1,6 @@
 class Specimen{
   constructor(shape, countX, countY, countZ, lengthA, lengthB, lengthC, angleA, angleB, angleC, scene, lineWeight){
-    this.mag = 10;
+    this.mag = 1;
     this.latticeColor = 0xff37d8;
     switch(shape){
     case 'square':

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -283,13 +283,13 @@ let showThanks = function(){
   $('#thanks').show();
 }
 
+let dbspecimens = []
+
 $(document).ready(function(){
-  let dbspecimens = JSON.parse(decodeURIComponent(location.href.split('?')[1]));
+  dbspecimens = JSON.parse(decodeURIComponent(location.href.split('?')[1]));
   for (let i = 0; i < dbspecimens.length; i++){
     let option = document.createElement('option');
-    option.id = dbspecimens[i].id;
     option.textContent = dbspecimens[i].Name;
-    option.value = dbspecimens[i].id;
     $('#importdatabasemenu').append(option)
   }
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -287,7 +287,9 @@ $(document).ready(function(){
   let dbspecimens = JSON.parse(decodeURIComponent(location.href.split('?')[1]));
   for (let i = 0; i < dbspecimens.length; i++){
     let option = document.createElement('option');
+    option.id = dbspecimens[i].id;
     option.textContent = dbspecimens[i].Name;
+    option.value = dbspecimens[i].id;
     $('#importdatabasemenu').append(option)
   }
 });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -282,3 +282,12 @@ addRowOnClick();
 let showThanks = function(){
   $('#thanks').show();
 }
+
+$(document).ready(function(){
+  let dbspecimens = JSON.parse(decodeURIComponent(location.href.split('?')[1]));
+  for (let i = 0; i < dbspecimens.length; i++){
+    let option = document.createElement('option');
+    option.textContent = dbspecimens[i].Name;
+    $('#importdatabasemenu').append(option)
+  }
+});

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -98,9 +98,9 @@ let importDatabaseSpecimen = function(){
   let importmenu = document.getElementById('importdatabasemenu');
   let obj = dbspecimens[importmenu.selectedIndex];
   $('#latticeselector').val(obj.CrystalStructure);
-  $('#lengthX').val(obj.LatticeA);
-  $('#lengthY').val(obj.LatticeB);
-  $('#lengthZ').val(obj.LatticeC);
+  $('#lengthX').val(obj.LatticeA * 10);
+  $('#lengthY').val(obj.LatticeB * 10);
+  $('#lengthZ').val(obj.LatticeC * 10);
   $('#angleA').val(obj.LatticeAlpha);
   $('#angleB').val(obj.LatticeBeta);
   $('#angleC').val(obj.LatticeGamma);

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -95,12 +95,14 @@ let onReaderLoad = function(event){
 
 let importDatabaseSpecimen = function(){
   clearAtomList();
-  /*$('#lengthX').val(obj.x);
-  $('#lengthY').val(obj.y);
-  $('#lengthZ').val(obj.z);
-  $('#angleA').val(obj.a);
-  $('#angleB').val(obj.b);
-  $('#angleC').val(obj.c);*/
+  let importmenu = document.getElementById('importdatabasemenu');
+  let obj = dbspecimens[importmenu.selectedIndex];
+  $('#lengthX').val(obj.LatticeA);
+  $('#lengthY').val(obj.LatticeB);
+  $('#lengthZ').val(obj.LatticeC);
+  $('#angleA').val(obj.LatticeAlpha);
+  $('#angleB').val(obj.LatticeBeta);
+  $('#angleC').val(obj.LatticeGamma);
 };
 
 let atomOnMouseup = function(e){

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -110,6 +110,19 @@ let importDatabaseSpecimen = function(){
   newSpecimen.changeLengthX($('#lengthX')[0].value);
   newSpecimen.changeLengthY($('#lengthY')[0].value);
   newSpecimen.changeLengthZ($('#lengthZ')[0].value);
+  let atoms = obj.AtomicCoordinates.split('[');
+  for(let i = 1; i < atoms.length; i++){
+    let atom = atoms[i].split(']')[0];
+    atom = atom.split(',');
+    console.log(atom)
+    if(atom.length < 5){
+      // No color value
+      addAtom(atom[1], atom[2], atom[3], '#00ff00', atom[0])
+    } else {
+      // Color value
+      addAtom(atom[1], atom[2], atom[3], atom[4], atom[0])
+    }
+  }
   newSpecimen.redrawCrystals();
 };
 

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -93,6 +93,15 @@ let onReaderLoad = function(event){
   $('#importlocallybutton')[0].value = null;
 };
 
+let importDatabaseSpecimen = function(){
+  clearAtomList();
+  /*$('#lengthX').val(obj.x);
+  $('#lengthY').val(obj.y);
+  $('#lengthZ').val(obj.z);
+  $('#angleA').val(obj.a);
+  $('#angleB').val(obj.b);
+  $('#angleC').val(obj.c);*/
+};
 
 let atomOnMouseup = function(e){
   let $container = closeWhenOffClickDiv;

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -97,6 +97,7 @@ let importDatabaseSpecimen = function(){
   clearAtomList();
   let importmenu = document.getElementById('importdatabasemenu');
   let obj = dbspecimens[importmenu.selectedIndex];
+  $('#latticeselector').val(obj.CrystalStructure);
   $('#lengthX').val(obj.LatticeA);
   $('#lengthY').val(obj.LatticeB);
   $('#lengthZ').val(obj.LatticeC);

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -123,6 +123,7 @@ let importDatabaseSpecimen = function(){
       addAtom(atom[1], atom[2], atom[3], atom[4], atom[0])
     }
   }
+  addRowOnClick();
   newSpecimen.redrawCrystals();
 };
 

--- a/public/js/onchange.js
+++ b/public/js/onchange.js
@@ -103,6 +103,13 @@ let importDatabaseSpecimen = function(){
   $('#angleA').val(obj.LatticeAlpha);
   $('#angleB').val(obj.LatticeBeta);
   $('#angleC').val(obj.LatticeGamma);
+  newSpecimen.changeAngleA($('#angleA')[0].value);
+  newSpecimen.changeAngleB($('#angleB')[0].value);
+  newSpecimen.changeAngleC($('#angleC')[0].value);
+  newSpecimen.changeLengthX($('#lengthX')[0].value);
+  newSpecimen.changeLengthY($('#lengthY')[0].value);
+  newSpecimen.changeLengthZ($('#lengthZ')[0].value);
+  newSpecimen.redrawCrystals();
 };
 
 let atomOnMouseup = function(e){

--- a/public/js/onclick.js
+++ b/public/js/onclick.js
@@ -16,7 +16,6 @@ let addRowOnClick = function(){
 
 $('#atomaddbutton').on('click', function(event){
   event.preventDefault();
-  let atom = $('#atominput')[0].value;
   let element = $('#elementinput').text();
   let x = $('#xinput')[0].value;
   let y = $('#yinput')[0].value;
@@ -28,7 +27,6 @@ $('#atomaddbutton').on('click', function(event){
 
   addRowOnClick();
 
-  $('#atominput')[0].value = '';
   $('#elementinput').text('');
   $('#xinput')[0].value = '0.0';
   $('#yinput')[0].value = '0.0';


### PR DESCRIPTION
The changes here support importing specimen data from the database. Note that the data must be passed in from the server, so the full functionality is only available on our website. (To see/test, go to the simulator at https://www.e-microscopy.org/TEMSimulator, open Examples & Applications, then open the lattice simulator). The import converts abc values from nm to Angstrom, hence multiplying the abc values by 10.

I also adjusted Bravais lattice options to match the ones on our specimen deposition page, along with other minor labeling adjustments. I removed references to the atominput element, since it is no longer present.